### PR TITLE
fixed non-working signing of other keys

### DIFF
--- a/keysign/Sections.py
+++ b/keysign/Sections.py
@@ -381,8 +381,11 @@ class GetKeySection(Gtk.VBox):
         self.log.debug('Adding %s as callback', callback)
         GLib.idle_add(callback, fingerprint, keydata, data)
 
-        # Remove the temporary keyring
-        gpg.gpg_reset_engine(self.ctx, tmp_gpghome)
+        # FIXME: Remove the temporary keyring.
+        #        We cannot do it right now, because the key is signed
+        #        later! If we delete the directory now, we cannot sign
+        #        it...
+        #gpg.gpg_reset_engine(self.ctx, tmp_gpghome)
         self.log.info("Deleting temporary gpg home dir: %s", tmp_gpghome)
 
         # If this function is added itself via idle_add, then idle_add will

--- a/keysign/Sections.py
+++ b/keysign/Sections.py
@@ -296,6 +296,9 @@ class GetKeySection(Gtk.VBox):
 
 
     def download_key_http(self, address, port):
+        '''Downloads a key from a keyserver and provides
+        bytes (as opposed to an unencoded string).
+        '''
         url = ParseResult(
             scheme='http',
             # This seems to work well enough with both IPv6 and IPv4
@@ -304,8 +307,9 @@ class GetKeySection(Gtk.VBox):
             params='',
             query='',
             fragment='')
-        return requests.get(url.geturl()).text
+        return requests.get(url.geturl()).text.encode('utf-8')
 
+    
     def try_download_keys(self, clients):
         for client in clients:
             self.log.debug("Getting key from client %s", client)

--- a/keysign/Sections.py
+++ b/keysign/Sections.py
@@ -576,5 +576,7 @@ class GetKeySection(Gtk.VBox):
 
     def recieved_key(self, fingerprint, keydata, *data):
         self.received_key_data = keydata
-        gpgmeKey = gpg.gpg_get_keylist(self.ctx, fingerprint, False)[0]
+        keylist =  gpg.gpg_get_keylist(self.ctx, fingerprint, False)
+        self.log.debug('Getting keylist: %r', keylist)
+        gpgmeKey = keylist[0]
         self.signPage.display_downloaded_key(gpg.gpg_format_key(gpgmeKey))

--- a/keysign/gpg/gpg.py
+++ b/keysign/gpg/gpg.py
@@ -102,13 +102,11 @@ def gpg_import_key(gpgmeContext, fpr):
 
 
 def gpg_import_keydata(gpgmeContext, keydata):
-    """Tries to import a OpenPGP key from @keydata
+    """Tries to import a OpenPGP key from @keydata.
+    Keydata needs to be bytes (or an encoded string).
 
     The @gpgmeContext object has a gpg directory already set.
     """
-    # XXX: PyGPGME key imports doesn't work with data as unicode strings
-    # but here we get data coming from network which is unicode
-    keydata = keydata.encode('utf-8')
     keydataIO = BytesIO(keydata)
     result = None
     try:

--- a/keysign/gpg/test.py
+++ b/keysign/gpg/test.py
@@ -118,13 +118,15 @@ class GpgTestSuite(unittest.TestCase):
             secret_key = fp.read()
 
         userId = ctx.get_key('john.doe@test.com').uids[0]
+        len_before = len(userId.signatures)
         res = gpg.gpg_sign_uid(ctx, tmpdir, userId, secret_key)
 
         self.assertTrue(res)
 
         # verify if we have the uid signed
         sigs = ctx.get_key('john.doe@test.com').uids[0].signatures
-        self.assertEqual(len(sigs), 2) #we're counting the self signature
+        len_after = len(sigs)
+        self.assertGreater(len_after, len_before)
 
 
 if __name__ == '__main__':

--- a/keysign/gpg/test.py
+++ b/keysign/gpg/test.py
@@ -27,8 +27,7 @@ import gpg
 
 import unittest
 
-from io import BytesIO
-from StringIO import StringIO
+from io import BytesIO, StringIO
 
 __all__ = ['GpgTestSuite']
 


### PR DESCRIPTION
I actually only want you to regard the last five commits (i.e. 4e3747ca89bc44fa9574eec7f8d7c9873a1b4f97..97eaa89d8f2ae59e5899750413259a2b98cccee3) which fix a few issues. It seems that there are more commits here, now :-/  I think it is because your pygpgme_integration branch is not advanced.

I think I found an issue with the pygpgme wrapper merge request here: https://github.com/muelli/geysigning/pull/44/ . It didn't work for me, because it deleted the temporary directory too early.

I am testing like this: I have two terminals open and start gnome-keysign in one of them. In the other, I run smth like `env GNUPGHOME=/var/tmp/gpg/ /tmp/gpgme/bin/python  ./gnome-keysign.py -vv`, e.g. I set GNUPGHOME to a directory I have created a secret key in. Then I try to transfer the key from one instance to the other.
